### PR TITLE
Annotate jpeg version

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,13 +22,13 @@ requirements:
         - python  # [win]
         - cmake  # [win]
         - msinttypes  # [win and py<35]
-        - jpeg
-        - zlib
         - bison  # [unix]
         - flex  # [unix]
-    run:
-        - jpeg
         - zlib
+        - jpeg 9b
+    run:
+        - zlib
+        - jpeg 9b
 
 test:
     commands:


### PR DESCRIPTION
No need to re-build as this was already built with the latest `jpeg 9b`.
