### PR TITLE
Enable shared libs

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -14,6 +14,7 @@ chmod +x configure
 ./configure --prefix=${PREFIX}\
             --enable-linux-lfs \
             --enable-silent-rules \
+            --enable-shared \
             --with-ssl \
             --with-zlib \
             --with-jpeg \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,6 +12,7 @@ source:
         - HDFTests.c.patch  # [win]
 
 build:
+    number: 1
     features:
         - vc9  # [win and py27]
         - vc10  # [win and py34]
@@ -36,6 +37,10 @@ test:
         - hdiff -V  # [unix]
         - test -f ${PREFIX}/lib/libdf.a  # [unix]
         - test -f ${PREFIX}/lib/libmfhdf.a  # [unix]
+        - test -f ${PREFIX}/lib/libdf.so  # [linux]
+        - test -f ${PREFIX}/lib/libdf.dylib  # [osx]
+        - test -f ${PREFIX}/lib/libmfhdf.so  # [linux]
+        - test -f ${PREFIX}/lib/libmfhdf.dylib  # [osx]
         - conda inspect linkages -n _test hdf4  # [linux]
 
 about:


### PR DESCRIPTION
We need shared libs so `netcdf` can use `hdf4`.
