### PR TITLE
Increasing the maximum file limit

### DIFF
--- a/recipe/max_files.patch
+++ b/recipe/max_files.patch
@@ -1,0 +1,12 @@
+diff -rupN hdf-4.2.11/hdf/src/hlimits.h new/hdf/src/hlimits.h
+--- hdf-4.2.11/hdf/src/hlimits.h	2014-02-10 02:28:49.000000000 +0000
++++ hdf/src/hlimits.h	2014-09-02 14:07:48.015297738 +0100
+@@ -88,7 +88,7 @@
+ /* ------------------------- Constants for hfile.c --------------------- */
+ /* Maximum number of files (number of slots for file records) */
+ #ifndef MAX_FILE
+-#   define MAX_FILE   32
++#   define MAX_FILE   4096
+ #endif /* MAX_FILE */
+ 
+ /* Maximum length of external filename(s) (used in hextelt.c) */


### PR DESCRIPTION
By default, the HDF4 libraries have a fixed limit on the number
of HDF4 simultaneously opened (it's 32). This limit is too small
for some applications, and the value can be increased safely to
much higher figures, which is what this patch does. The patch
is provided, and also referred to in the `meta.yaml` file. This
patch had been accepted in the previous conda recipes github
repository, but the changes never migrated here.
