### PR TITLE
The maximum files patch wasn't applied as it wasn't in the meta.yaml file

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,6 +10,8 @@ source:
     sha256: bb0e900b8cc6bc89a5730abc97e654e7705e8e1fbc4e0d4477f417822428d99b
     patches:
         - HDFTests.c.patch  # [win]
+        - max_files.patch
+
 
 build:
     number: 3

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
 
 
 build:
-    number: 3
+    number: 5
     features:
         - vc9  # [win and py27]
         - vc10  # [win and py34]


### PR DESCRIPTION
In my previous PR, I forgot to add the maximum files patch to the meta.yaml file, which means that although the patch is in the source tree, it doesn't get applied. This has now been solved, and I have checked that the patch is applied. Sorry for this!
