### PR TITLE
Use PREFIX in tests rather than an environment name

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,8 +42,8 @@ test:
         - test -f ${PREFIX}/lib/libdf.dylib  # [osx]
         - test -f ${PREFIX}/lib/libmfhdf.so  # [linux]
         - test -f ${PREFIX}/lib/libmfhdf.dylib  # [osx]
-        - conda inspect linkages -p ${PREFIX} hdf4  # [not win]
-        - conda inspect objects -p ${PREFIX} hdf4  # [osx]
+        - conda inspect linkages -p ${CONDA_DEFAULT_ENV} hdf4  # [not win]
+        - conda inspect objects -p ${CONDA_DEFAULT_ENV} hdf4  # [osx]
 
 about:
     home: http://www.hdfgroup.org/HDF4/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,8 +42,8 @@ test:
         - test -f ${PREFIX}/lib/libdf.dylib  # [osx]
         - test -f ${PREFIX}/lib/libmfhdf.so  # [linux]
         - test -f ${PREFIX}/lib/libmfhdf.dylib  # [osx]
-        - conda inspect linkages -n _test hdf4  # [not win]
-        - conda inspect objects -n _test hdf4  # [osx]
+        - conda inspect linkages -p ${PREFIX} hdf4  # [not win]
+        - conda inspect objects -p ${PREFIX} hdf4  # [osx]
 
 about:
     home: http://www.hdfgroup.org/HDF4/


### PR DESCRIPTION
When I try to build this recipe locally (with conda_build_all), the test:
`conda inspect linkages -n _test hdf4`
is failing as it can't seem to find the _test environment.

When I use `-p ${PREFIX}` rather than `-n _test`, it does work.
